### PR TITLE
Remove unnecessary channels.join API request

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -553,7 +553,6 @@ class Channel(object):
         if update_remote:
             if "join" in SLACK_API_TRANSLATOR[self.type]:
                 async_slack_api_request(self.server.domain, self.server.token, SLACK_API_TRANSLATOR[self.type]["join"], {"name": self.name.lstrip("#")})
-                async_slack_api_request(self.server.domain, self.server.token, SLACK_API_TRANSLATOR[self.type]["join"], {"user": users.find(self.name).identifier})
 
     def close(self, update_remote=True):
         #remove from cache so messages don't reappear when reconnecting


### PR DESCRIPTION
There are two problems with this API request:
1. According to https://api.slack.com/methods/channels.join, "user" is
   not a valid argument.
2. The hash table lookup in the removed line of code is destined to fail
   anyway, because `self.name` here refers to the channel name, which
   is not present in the `users` SearchList() instance as it maps
   usernames to the Slack API user IDs. Indeed, this causes the call to
   `users.find(self.name)` to return `None`, causing an
   AttributeError to be raised.

Fixes #190.
